### PR TITLE
Fix js file path

### DIFF
--- a/src/recharts/component/DefaultLegendContent.hx
+++ b/src/recharts/component/DefaultLegendContent.hx
@@ -47,6 +47,6 @@ typedef DefaultLegendContentProps<TPayload, TValue, TID> = {
 	@:optional var onMouseLeave:TypedRechartsHandler<LegendPayload<TPayload, TValue, TID>, DOMElement, MouseEvent<DOMElement>>;
 }
 
-@:jsRequire('recharts/component/DefaultLegendContent', 'DefaultLegendContent')
+@:jsRequire('recharts/es6/component/DefaultLegendContent', 'DefaultLegendContent')
 extern class DefaultLegendContent<TPayload, TValue, TID>
 extends ReactComponentOfProps<DefaultLegendContentProps<TPayload, TValue, TID>> {}

--- a/src/recharts/component/DefaultTooltipContent.hx
+++ b/src/recharts/component/DefaultTooltipContent.hx
@@ -31,6 +31,6 @@ typedef DefaultTooltipContentProps<TValue:ValueType, TName:NameType> = {
 	@:optional var itemSorter:TooltipPayload<TValue, TName>->StringOrFloat; // ?!
 }
 
-@:jsRequire('recharts/component/DefaultTooltipContent', 'DefaultTooltipContent')
+@:jsRequire('recharts/es6/component/DefaultTooltipContent', 'DefaultTooltipContent')
 extern class DefaultTooltipContent<TValue:ValueType, TName:NameType>
 extends ReactComponentOfProps<DefaultTooltipContentProps<TValue, TName>> {}


### PR DESCRIPTION
Hi,
The paths for the component DefaultLegendContent and DefaultTooltipContent are not correct.
It does not fit with the npm module.
I suggest to replace `@:jsRequire('recharts/...` by `@:jsRequire('recharts/es6/...`.